### PR TITLE
Add save/load support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - Sidebars for player info and travel destinations.
 - Dev console for debugging or cheat commands.
 - Inventory and equipment system rendered in modal with hover tooltips.
+- Save and load progress via browser storage.
 
 ### Modular Code Structure
 
@@ -60,7 +61,7 @@
 
 ### 5. **UI/UX Additions**
 
-- Save/load system using browser storage.
+- ~~Save/load system using browser storage.~~ Implemented!
 - Music and sound effects toggle in settings.
 - Visual transitions between locations.
 

--- a/game.js
+++ b/game.js
@@ -12,7 +12,28 @@ import { getAllEntries, unlockJournalEntry, getUnlockedEntries } from './journal
 
 let activeJournalCategory = 'all';
 let currentEnemy = null; // Initialize current enemy
-let draggedItemID = null; // For drag-and-drop 
+let draggedItemID = null; // For drag-and-drop
+
+function saveGame() {
+  try {
+    localStorage.setItem('saveGame', JSON.stringify(player));
+    log('Game saved.', { type: 'info' });
+  } catch (e) {
+    alert('Failed to save game.');
+  }
+}
+
+function loadSavedGame() {
+  const data = localStorage.getItem('saveGame');
+  if (data) {
+    try {
+      const parsed = JSON.parse(data);
+      Object.assign(player, parsed);
+    } catch (e) {
+      console.error('Failed to load save', e);
+    }
+  }
+}
 
 function getEquippedWeapon() {
   const id = player.equipment["main-hand"];
@@ -26,6 +47,11 @@ window.talkToNpc = talkToNpc;
 let isDragging = false; // Track if an item is being dragged
 
 document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('load') === '1') {
+    loadSavedGame();
+  }
+
   setupSidebar();
   setupStatsModal();
   renderHud();
@@ -89,10 +115,7 @@ function setupSidebar() {
     { label: "Stats", handler: openStats },
     { label: "Inventory", handler: openInventory },
     { label: "Quests", handler: openQuests },
-    { label: "Save Game", handler: () => {
-      console.log("Saving game... returning to menu.");
-      window.location.href = "index.html";
-    }},
+    { label: "Save Game", handler: saveGame },
     { label: "Settings", handler: openSettings },
     { label: "Journal", handler: openJournal },
   ];

--- a/script.js
+++ b/script.js
@@ -13,11 +13,20 @@ let selectedIndex = 0;
 
 menuItems[selectedIndex].classList.add('selected');
 
-fetch('version.json')
-  .then((res) => res.json())
-  .then((data) => {
-    document.getElementById('version').textContent = `Version: ${data.version}`;
-  });
+  fetch('version.json')
+    .then((res) => res.json())
+    .then((data) => {
+      document.getElementById('version').textContent = `Version: ${data.version}`;
+    });
+
+function loadGame() {
+  const data = localStorage.getItem('saveGame');
+  if (data) {
+    window.location.href = 'game.html?load=1';
+  } else {
+    typeMessage('> No saved game found.');
+  }
+}
 
 
 function typeMessage(message) {
@@ -73,6 +82,8 @@ document.addEventListener('keydown', (e) => {
       setTimeout(() => {
         window.location.href = 'game.html';
       }, 1000);
+    } else if (selectedOption === 'Load Game') {
+      loadGame();
     }
   }
 });
@@ -86,6 +97,10 @@ document.querySelectorAll('.menu li').forEach((item) => {
       setTimeout(() => {
         window.location.href = 'game.html';
       }, 1000);
+    }
+
+    if (option === 'Load Game') {
+      loadGame();
     }
 
     if (option === 'Credits') {


### PR DESCRIPTION
## Summary
- allow saving player data to localStorage
- load saves from main menu
- hook up sidebar save button
- document save/load feature

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ad7304bf48329bc616271ebb3d15b