### PR TITLE
Implement consumable usage helper

### DIFF
--- a/game.js
+++ b/game.js
@@ -4,6 +4,7 @@ import { locations } from './location.js';
 console.log("Loaded locations:", locations);
 import { items } from './items.js';
 console.log("Loaded items:", items);
+import { useItem } from './itemUtils.js';
 import { enemies } from './enemy.js';
 console.log("Loaded enemies:", enemies);
 import { talkToNpc, closeNpcModal } from './npc.js';
@@ -602,7 +603,7 @@ function handleItemAction(action, itemId) {
   }
 } else if (action === 'use') {
     console.log(`Using ${itemId}`);
-    // TODO: implement use logic
+    useItem(itemId);
   } else if (action === 'drop') {
     console.log(`Dropping ${itemId}`);
     // Remove from player inventory

--- a/itemUtils.js
+++ b/itemUtils.js
@@ -1,0 +1,53 @@
+import { player } from './player.js';
+import { items } from './items.js';
+
+export function useItem(itemId) {
+  const item = items[itemId];
+  if (!item || item.type !== 'consumable') {
+    console.warn(`Item ${itemId} cannot be used.`);
+    return false;
+  }
+
+  const invEntry = player.inventory.find(entry => entry.id === itemId);
+  if (!invEntry) {
+    console.warn(`Item ${itemId} not found in inventory.`);
+    return false;
+  }
+
+  invEntry.quantity -= 1;
+  if (invEntry.quantity <= 0) {
+    player.inventory = player.inventory.filter(entry => entry.id !== itemId);
+  }
+
+  if (item.effects) {
+    item.effects.forEach(effect => {
+      switch (effect.type) {
+        case 'heal':
+          player.derivedStats.hp = Math.min(
+            player.derivedStats.hp + effect.amount,
+            player.derivedStats.maxHp
+          );
+          break;
+        case 'restore_mp':
+          player.derivedStats.mp = Math.min(
+            player.derivedStats.mp + effect.amount,
+            player.derivedStats.maxMp
+          );
+          break;
+      }
+    });
+  }
+
+  if (typeof globalThis.renderHud === 'function') {
+    globalThis.renderHud();
+  }
+  if (typeof globalThis.renderInventory === 'function') {
+    globalThis.renderInventory();
+  }
+  if (typeof globalThis.log === 'function') {
+    const name = item.name || itemId;
+    globalThis.log(`Used ${name}.`);
+  }
+
+  return true;
+}

--- a/tests/useItem.test.js
+++ b/tests/useItem.test.js
@@ -1,0 +1,33 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { player } from '../player.js';
+import { useItem } from '../itemUtils.js';
+
+// Stub UI functions for tests
+global.renderHud = () => {};
+global.renderInventory = () => {};
+global.log = () => {};
+
+test('using healing potion restores hp and reduces quantity', () => {
+  const entry = player.inventory.find(i => i.id === 'healing_potion');
+  const originalQty = entry ? entry.quantity : 0;
+  const originalHp = player.derivedStats.hp;
+  // Lower HP to test healing
+  player.derivedStats.hp = Math.max(0, originalHp - 10);
+
+  useItem('healing_potion');
+
+  const expectedHp = Math.min(originalHp - 10 + 20, player.derivedStats.maxHp);
+  assert.strictEqual(player.derivedStats.hp, expectedHp);
+  const newEntry = player.inventory.find(i => i.id === 'healing_potion');
+  const newQty = newEntry ? newEntry.quantity : 0;
+  assert.strictEqual(newQty, originalQty - 1);
+
+  // cleanup
+  if (newEntry) {
+    newEntry.quantity += 1;
+  } else {
+    player.inventory.push({ id: 'healing_potion', quantity: 1 });
+  }
+  player.derivedStats.hp = originalHp;
+});


### PR DESCRIPTION
## Summary
- add a reusable `useItem` helper for consumables
- wire `handleItemAction` to call `useItem`
- test potion use restores health and consumes the item

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ae7826a948329968fec3f0857ffd2