### PR TITLE
Improve keyboard accessibility for menu items

### DIFF
--- a/game.css
+++ b/game.css
@@ -566,6 +566,16 @@ legend {
   text-shadow: 0 0 6px var(--color-accent);
 }
 
+.sidebar li:focus {
+  outline: 2px dashed var(--color-accent);
+  outline-offset: 2px;
+}
+
+li[role="button"]:focus {
+  outline: 2px dashed var(--color-accent);
+  outline-offset: 2px;
+}
+
 .sidebar-wrapper {
   height: 100%;
   display: flex;

--- a/game.html
+++ b/game.html
@@ -58,11 +58,11 @@
         <div class="sidebar">
           <h3>Player Menu</h3>
           <ul>
-            <li id="open-stats">Stats</li>
-            <li id="open-inventory">Inventory</li>
-            <li id="open-quests">Quests</li>
-            <li id="open-save">Save Game</li>
-            <li id="open-settings">Settings</li>
+            <li id="open-stats" role="button" tabindex="0">Stats</li>
+            <li id="open-inventory" role="button" tabindex="0">Inventory</li>
+            <li id="open-quests" role="button" tabindex="0">Quests</li>
+            <li id="open-save" role="button" tabindex="0">Save Game</li>
+            <li id="open-settings" role="button" tabindex="0">Settings</li>
           </ul>
         </div>
         <div class="sidebar-tab">TAB</div>

--- a/game.js
+++ b/game.js
@@ -126,7 +126,15 @@ function setupSidebar() {
   menuDefinitions.forEach(({ label, handler }) => {
     const li = document.createElement("li");
     li.textContent = label;
+    li.setAttribute("role", "button");
+    li.setAttribute("tabindex", "0");
     li.addEventListener("click", handler);
+    li.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        handler();
+      }
+    });
     sidebarList.appendChild(li);
   });
 
@@ -176,11 +184,19 @@ function renderDestinationSidebar() {
   current.connections.forEach(dest => {
     const li = document.createElement('li');
     li.textContent = dest;
+    li.setAttribute('role', 'button');
+    li.setAttribute('tabindex', '0');
     li.addEventListener('click', () => {
       if (player.inCombat) return;
       player.location = dest;
       renderLocation();
       renderDestinationSidebar();  // refresh right sidebar
+    });
+    li.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        li.click();
+      }
     });
     list.appendChild(li);
   });
@@ -502,9 +518,17 @@ function openContextMenu(itemId, x, y, equipped = false) {
   actions.forEach(action => {
     const li = document.createElement('li');
     li.textContent = action;
+    li.setAttribute('role', 'button');
+    li.setAttribute('tabindex', '0');
     li.addEventListener('click', () => {
       handleItemAction(action.toLowerCase(), itemId);
       closeContextMenu();
+    });
+    li.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        li.click();
+      }
     });
     menu.appendChild(li);
   });
@@ -1236,7 +1260,15 @@ function renderNpcSidebar(npcList) {
     const li = document.createElement("li");
     li.textContent = npc.name;
     li.classList.add("sidebar-npc-entry");
+    li.setAttribute("role", "button");
+    li.setAttribute("tabindex", "0");
     li.onclick = () => talkToNpc(id);
+    li.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        li.click();
+      }
+    });
     npcUl.appendChild(li);
   });
 

--- a/index.html
+++ b/index.html
@@ -18,10 +18,10 @@
     <div class="menu-container">
       <h1>Caford Chronicles</h1>
       <ul class="menu">
-        <li id="start">Start Game</li>
-        <li id="load">Load Game</li>
-        <li id="options">Options</li>
-        <li id="credits">Credits</li>
+        <li id="start" role="button" tabindex="0">Start Game</li>
+        <li id="load" role="button" tabindex="0">Load Game</li>
+        <li id="options" role="button" tabindex="0">Options</li>
+        <li id="credits" role="button" tabindex="0">Credits</li>
       </ul>
       <div id="message" class="message-box"></div>
     </div>

--- a/script.js
+++ b/script.js
@@ -90,6 +90,7 @@ document.addEventListener('keydown', (e) => {
 
 document.querySelectorAll('.menu li').forEach((item) => {
   const option = item.textContent;
+
   item.addEventListener('click', () => {
     typeMessage(`> ${option} selected.`);
 
@@ -105,6 +106,13 @@ document.querySelectorAll('.menu li').forEach((item) => {
 
     if (option === 'Credits') {
       document.getElementById('credits-modal').classList.remove('hidden');
+    }
+  });
+
+  item.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      item.click();
     }
   });
 });

--- a/styles.css
+++ b/styles.css
@@ -108,6 +108,16 @@ body {
   text-shadow: 0 0 6px #f9df6a, 0 0 12px #dabd50;
 }
 
+.menu li:focus {
+  outline: 2px dashed #f9df6a;
+  outline-offset: 2px;
+}
+
+li[role="button"]:focus {
+  outline: 2px dashed #f9df6a;
+  outline-offset: 2px;
+}
+
 .modal {
   position: fixed;
   top: 0;


### PR DESCRIPTION
## Summary
- add `tabindex` and `role="button"` to clickable list items
- highlight list items when focused
- allow pressing Enter/Space on interactive list items

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aeaa7e0848329b17b6e48e2dddd7d