### PR TITLE
Improve modal accessibility

### DIFF
--- a/game.html
+++ b/game.html
@@ -126,9 +126,10 @@
     </div> <!-- end .content-row -->
 
     <!-- MODALS -->
-    <div id="stats-modal" class="modal hidden draggable-window">
+    <div id="stats-modal" class="modal hidden draggable-window" role="dialog" aria-labelledby="stats-title" aria-describedby="stats-desc" tabindex="-1">
       <div class="modal-content">
-        <h2>Player Stats</h2>
+        <h2 id="stats-title">Player Stats</h2>
+        <p id="stats-desc" class="sr-only">Player statistics</p>
 
         <div class="stat-group">
           <h3>Core Attributes</h3>
@@ -167,9 +168,10 @@
       </div>
     </div>
 
-    <div id="options-modal" class="modal hidden">
+    <div id="options-modal" class="modal hidden" role="dialog" aria-labelledby="options-title" aria-describedby="options-desc" tabindex="-1">
       <div class="modal-content">
-        <h2>Options</h2>
+        <h2 id="options-title">Options</h2>
+        <p id="options-desc" class="sr-only">Game options</p>
         <div>
           <label for="ui-scale">UI Scale:</label>
           <select id="ui-scale">
@@ -189,7 +191,7 @@
       <input type="text" id="console-input" placeholder="> Type command..." />
     </div>
 
-    <div id="story-event-modal" class="modal hidden">
+    <div id="story-event-modal" class="modal hidden" role="dialog" aria-labelledby="story-event-title" aria-describedby="story-event-text" tabindex="-1">
       <fieldset class="modal-content" id="story-event-content">
         <legend>Story Event</legend>
         <h2 id="story-event-title">Story Event</h2>
@@ -199,7 +201,7 @@
       <!-- <button id="close-event">Close</button> -->
     </div>
 
-    <div id="npc-modal" class="modal hidden draggable-window">
+    <div id="npc-modal" class="modal hidden draggable-window" role="dialog" aria-labelledby="npc-name" aria-describedby="npc-dialogue-text" tabindex="-1">
       <div class="modal-content">
         <img id="npc-portrait" class="location-art" />
         <h2 id="npc-name">NPC Name</h2>
@@ -210,10 +212,11 @@
     </div>
 
 
-    <div id="inventory-modal" class="modal hidden draggable-window">
+    <div id="inventory-modal" class="modal hidden draggable-window" role="dialog" aria-labelledby="inventory-title" aria-describedby="inventory-desc" tabindex="-1">
       <div class="modal-content inventory-layout">
         <div class="drag-handle"></div>
-        <h2>Inventory</h2>
+        <h2 id="inventory-title">Inventory</h2>
+        <p id="inventory-desc" class="sr-only">Player inventory and equipped gear</p>
         <div class="inventory-columns">
           <div class="inventory-list">
             <h3>Backpack</h3>
@@ -236,11 +239,11 @@
       </div>
     </div>
 
-    <div id="journal-modal" class="modal hidden">
+    <div id="journal-modal" class="modal hidden" role="dialog" aria-labelledby="journal-title" aria-describedby="journal-progress" tabindex="-1">
       <div class="modal-content" style="display: flex; gap: 1rem;">
         <!-- LEFT: Entry List -->
         <div style="width: 45%;">
-          <h2>📘 Journal</h2>
+          <h2 id="journal-title">📘 Journal</h2>
           <div id="journal-list"></div>
           <p id="journal-progress" style="font-size: 0.4rem; text-align: right; margin-top: 0.5rem;"></p>
           <button id="close-journal" style="margin-top: 1rem;">Close</button>

--- a/game.js
+++ b/game.js
@@ -45,6 +45,21 @@ window.talkToNpc = talkToNpc;
 
 // functionality
 let isDragging = false; // Track if an item is being dragged
+let lastFocusedElement = null;
+
+function openModal(modal) {
+  lastFocusedElement = document.activeElement;
+  modal.classList.remove('hidden');
+  modal.focus();
+}
+
+function closeModal(modal) {
+  modal.classList.add('hidden');
+  if (lastFocusedElement) {
+    lastFocusedElement.focus();
+    lastFocusedElement = null;
+  }
+}
 
 document.addEventListener('DOMContentLoaded', () => {
   const params = new URLSearchParams(window.location.search);
@@ -97,7 +112,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.getElementById('options-modal').addEventListener('click', (e) => {
     if (e.target.id === 'options-modal') {
-      e.currentTarget.classList.add('hidden');
+      closeModal(e.currentTarget);
     }
   });
 
@@ -152,11 +167,20 @@ function setupSidebar() {
 
 
 function openStats() {
-  document.getElementById("stats-modal").classList.remove("hidden");
+  const modal = document.getElementById("stats-modal");
+  openModal(modal);
+}
+
+function closeStats() {
+  closeModal(document.getElementById("stats-modal"));
 }
 
 function openInventory() {
-  document.getElementById("inventory-modal").classList.remove("hidden");
+  openModal(document.getElementById("inventory-modal"));
+}
+
+function closeInventory() {
+  closeModal(document.getElementById("inventory-modal"));
 }
 
 function openQuests() {
@@ -164,7 +188,11 @@ function openQuests() {
 }
 
 function openSettings() {
-  document.getElementById('options-modal').classList.remove('hidden');
+  openModal(document.getElementById('options-modal'));
+}
+
+function closeSettings() {
+  closeModal(document.getElementById('options-modal'));
 }
 
 
@@ -193,16 +221,14 @@ function setupStatsModal() {
   const closeBtn = document.getElementById('close-stats');
 
   statsBtn.addEventListener('click', () => {
-    modal.classList.remove('hidden');
     renderStatsToModal();
+    openStats();
   });
 
-  closeBtn.addEventListener('click', () => {
-    modal.classList.add('hidden');
-  });
+  closeBtn.addEventListener('click', closeStats);
 
   document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape') modal.classList.add('hidden');
+    if (e.key === 'Escape') closeStats();
   });
 }
 
@@ -722,15 +748,13 @@ consoleInput.addEventListener('keydown', (e) => {
 });
 
 document.getElementById('open-inventory').addEventListener('click', () => {
-  document.getElementById('inventory-modal').classList.remove('hidden');
+  openInventory();
   renderInventory();
   renderEquipped();
   renderStatsToModal();
 });
 
-document.getElementById('close-inventory').addEventListener('click', () => {
-  document.getElementById('inventory-modal').classList.add('hidden');
-});
+document.getElementById('close-inventory').addEventListener('click', closeInventory);
 
 function pickUpItem(itemId) {
   const loc = locations[player.location];
@@ -1138,7 +1162,7 @@ export function showStoryEventDialog(title, description, choices) {
 
       const closeBtn = document.createElement("button");
       closeBtn.textContent = "Close";
-      closeBtn.onclick = () => modal.classList.add("hidden");
+      closeBtn.onclick = () => closeModal(modal);
       choicesContainer.appendChild(closeBtn);
 
       // ✅ Rebind tooltips after dynamic result HTML is added
@@ -1147,7 +1171,7 @@ export function showStoryEventDialog(title, description, choices) {
     choicesContainer.appendChild(btn);
   });
 
-  modal.classList.remove("hidden");
+  openModal(modal);
 
   // ✅ Initial bind for tooltip-items in description
   bindTooltips(modal);
@@ -1215,7 +1239,7 @@ document.querySelectorAll('.sidebar li').forEach(li => {
 
 // Close button for Options Modal
 document.getElementById('close-options').addEventListener('click', () => {
-  document.getElementById('options-modal').classList.add('hidden');
+  closeSettings();
 });
 
 // On change
@@ -1371,9 +1395,9 @@ function openJournal() {
   );
   document.querySelector('.journal-tab[data-category="all"]')?.classList.add("active");
 
-  document.getElementById("journal-modal").classList.remove("hidden");
+  openModal(document.getElementById("journal-modal"));
 }
 
 function closeJournal() {
-  document.getElementById("journal-modal").classList.add("hidden");
+  closeModal(document.getElementById("journal-modal"));
 }

--- a/styles.css
+++ b/styles.css
@@ -218,3 +218,15 @@ body {
 .hidden {
   display: none;
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- add `sr-only` class
- label all modal containers with `role="dialog"`, `aria-labelledby`, and `aria-describedby`
- manage focus when modals open and close

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aeaaea6e88329b34eab07f872ccfb