### PR TITLE
Improve getEquippedWeapon and add tests

### DIFF
--- a/equipment.js
+++ b/equipment.js
@@ -1,0 +1,8 @@
+import { player } from './player.js';
+import { items } from './items.js';
+
+export function getEquippedWeapon() {
+  const slotVal = player.equipment["main-hand"];
+  if (!slotVal) return null;
+  return typeof slotVal === 'string' ? items[slotVal] : slotVal;
+}

--- a/game.js
+++ b/game.js
@@ -5,6 +5,7 @@ console.log("Loaded locations:", locations);
 import { items } from './items.js';
 console.log("Loaded items:", items);
 import { useItem } from './itemUtils.js';
+import { getEquippedWeapon } from './equipment.js';
 import { enemies } from './enemy.js';
 console.log("Loaded enemies:", enemies);
 import { talkToNpc, closeNpcModal } from './npc.js';
@@ -35,10 +36,6 @@ function loadSavedGame() {
   }
 }
 
-function getEquippedWeapon() {
-  const id = player.equipment["main-hand"];
-  return id ? items[id.id] : null;
-}
 
 window.closeNpcModal = closeNpcModal;
 window.talkToNpc = talkToNpc;

--- a/tests/getEquippedWeapon.test.js
+++ b/tests/getEquippedWeapon.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { player } from '../player.js';
+import { items } from '../items.js';
+import { getEquippedWeapon } from '../equipment.js';
+
+// Ensure inventory and equipment resetting
+const original = player.equipment["main-hand"];
+
+test('returns item object when equipment slot stores id string', () => {
+  player.equipment["main-hand"] = 'iron_sword';
+  const weapon = getEquippedWeapon();
+  assert.strictEqual(weapon, items['iron_sword']);
+});
+
+test('returns item object when equipment slot stores object', () => {
+  player.equipment["main-hand"] = items['iron_sword'];
+  const weapon = getEquippedWeapon();
+  assert.strictEqual(weapon, items['iron_sword']);
+});
+
+// restore original value
+player.equipment["main-hand"] = original;


### PR DESCRIPTION
## Summary
- centralize `getEquippedWeapon` in a new module
- update `game.js` to use the shared helper
- add tests for both string and object equipment values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aee7c011c832981e6a5c96e6ccde4