### PR TITLE
Fix XP gain in event

### DIFF
--- a/events.js
+++ b/events.js
@@ -121,7 +121,7 @@ export const events = {
               text: "Continue",
               action: () => {
                 player.progression.completedEvents.push("ruins-echoes");
-                player.progression.xp += 10;
+                player.xp += 10;
                 renderHud();
                 return "The vision fades. You feel the weight of unseen memories... and gain 10 XP.";
               }


### PR DESCRIPTION
## Summary
- ensure the Echoes of War event adds XP to `player.xp`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684af468e2288329b9a04bb4e53e5e72