### PR TITLE
Fix stray dialog line in event handling

### DIFF
--- a/game.js
+++ b/game.js
@@ -1223,7 +1223,6 @@ export function triggerEventsFor(location, triggerType) {
     ) {
       event.effect(player, location);
       console.log(`Event: ${event.name} triggered.`);
-      event.showStoryEventDialog;
 
       return true; // An event triggered
     }


### PR DESCRIPTION
## Summary
- remove orphaned `event.showStoryEventDialog` line in `triggerEventsFor`

## Testing
- `npm test`
- manual verification that `triggerEventsFor` still calls event effects

------
https://chatgpt.com/codex/tasks/task_e_684af4e5228883299dd4a90211cffd8c