### PR TITLE
Add journal entries for new locations and NPCs

### DIFF
--- a/game.js
+++ b/game.js
@@ -1350,7 +1350,7 @@ function renderJournal() {
 
   list.innerHTML = "";
 
-  const categories = ['enemy', 'location', 'legend'];
+  const categories = ['enemy', 'location', 'npc', 'legend'];
   const entries = getAllEntries();
 
   categories.forEach(cat => {

--- a/journal.js
+++ b/journal.js
@@ -1,5 +1,6 @@
 import { enemies } from './enemy.js';
 import { locations } from './location.js';
+import { npcs } from './npcs.js';
 import { log } from './game.js'
 
 // journal.js
@@ -31,6 +32,21 @@ Object.values(locations).forEach(location => {
       category: "location",
       locationHint: location.journal.locationHint,
       tags: location.journal.tags || []
+    };
+  }
+});
+
+// Load NPC-based journal entries
+Object.values(npcs).forEach(npc => {
+  if (npc.journal) {
+    journalEntries[npc.id] = {
+      id: npc.id,
+      title: npc.journal.title,
+      text: npc.journal.text,
+      unlocked: false,
+      category: "npc",
+      locationHint: npc.journal.locationHint,
+      tags: npc.journal.tags || []
     };
   }
 });

--- a/location.js
+++ b/location.js
@@ -103,7 +103,13 @@ export const locations = {
   npcs: [],
   hostiles: ["gladefang_wolf", "hollow_eyed_watcher", "barbed_stag"],
   loot: ["old_map_fragment", "glimmering_root", "rusted_signet"],
-  tags: ["forest", "ruins", "road"]
+  tags: ["forest", "ruins", "road"],
+  journal: {
+    title: "Moss-Eaten Path",
+    text: "A once-proud roadway now lost beneath creeping moss. Travelers whisper that memories cling to every stone here.",
+    locationHint: "Between the Whispering Glade and the Ruined Outpost",
+    tags: ["location", "forest", "ruins"]
+  }
   },
   'Market Square': {
     id: 'market-square',
@@ -115,7 +121,13 @@ export const locations = {
     npcs: ['town_merchant'],
     hostiles: [],
     loot: [],
-    tags: ['town']
+    tags: ['town'],
+    journal: {
+      title: 'Market Square',
+      text: 'The heart of Oakheart commerce, where news and coin change hands in equal measure.',
+      locationHint: 'Within Oakheart Village',
+      tags: ['location', 'town']
+    }
   },
   'Blacksmith Forge': {
     id: 'blacksmith-forge',
@@ -127,7 +139,13 @@ export const locations = {
     npcs: ['town_blacksmith'],
     hostiles: [],
     loot: [],
-    tags: ['town']
+    tags: ['town'],
+    journal: {
+      title: 'Blacksmith Forge',
+      text: 'Borik\'s anvil rings from dawn till dusk, shaping the weapons that defend Oakheart.',
+      locationHint: 'Adjacent to Market Square',
+      tags: ['location', 'town']
+    }
   },
   'The Sleepy Stoat': {
     id: 'sleepy-stoat',
@@ -139,6 +157,12 @@ export const locations = {
     npcs: ['innkeeper'],
     hostiles: [],
     loot: [],
-    tags: ['town']
+    tags: ['town'],
+    journal: {
+      title: 'The Sleepy Stoat',
+      text: 'Many a quest begins over a mug of frothy ale at this humble tavern.',
+      locationHint: 'Oakheart Village',
+      tags: ['location', 'town']
+    }
   }
 };

--- a/npc.js
+++ b/npc.js
@@ -1,5 +1,6 @@
 import { npcs } from './npcs.js';
 import { player } from './player.js'
+import { unlockJournalEntry } from './journal.js';
 
 let currentNpc = null;
 let currentNode = null;
@@ -8,6 +9,8 @@ export function talkToNpc(npcId) {
     const npc = npcs[npcId];
     if (!npc) return;
     if (player.inCombat) return;
+
+    unlockJournalEntry(npc.id);
 
     currentNpc = npc;
     currentNode = 'start';

--- a/npcs.js
+++ b/npcs.js
@@ -6,6 +6,12 @@ export const npcs = {
     name: "Old Mystic",
     location: "whispering-glade",
     portrait: "assets/npcs/old_mystic.png", // You can update this to your image path
+    journal: {
+      title: "Old Mystic",
+      text: "A reclusive seer muttering about forgotten futures and forest memories.",
+      locationHint: "Whispering Glade",
+      tags: ["npc"]
+    },
     dialogue: {
       "start": {
         text: `<span style="color: #dabd50;"><em>A hunched figure emerges from the mist, eyes glowing faintly beneath a hood.</em></span><br><br>\"Ah... another soul adrift in the glade.\"`,
@@ -79,6 +85,12 @@ export const npcs = {
     name: "Marla the Merchant",
     location: "oakheart-village",
     portrait: "assets/npcs/merchant.png",
+    journal: {
+      title: "Marla the Merchant",
+      text: "Always ready with a smile and a bargain, Marla keeps Oakheart supplied with necessities and gossip.",
+      locationHint: "Oakheart Village",
+      tags: ["npc"]
+    },
     dialogue: {
       "start": {
         text: "Welcome traveler! Care to browse my wares?",
@@ -97,6 +109,12 @@ export const npcs = {
     name: "Borik the Smith",
     location: "oakheart-village",
     portrait: "assets/npcs/blacksmith.png",
+    journal: {
+      title: "Borik the Smith",
+      text: "Gruff but dependable, Borik forges the arms that keep the village safe.",
+      locationHint: "Blacksmith Forge",
+      tags: ["npc"]
+    },
     dialogue: {
       "start": {
         text: "Weapons, armor... I forge it all.",
@@ -113,6 +131,12 @@ export const npcs = {
     name: "Tomas the Innkeeper",
     location: "oakheart-village",
     portrait: "assets/npcs/innkeeper.png",
+    journal: {
+      title: "Tomas the Innkeeper",
+      text: "Keeper of the Sleepy Stoat, Tomas always has a warm meal and a tale for those who linger.",
+      locationHint: "The Sleepy Stoat",
+      tags: ["npc"]
+    },
     dialogue: {
       "start": {
         text: "Need a place to rest? The beds are clean enough.",


### PR DESCRIPTION
## Summary
- add missing journal entries to Moss-Eaten Path, Market Square, Blacksmith Forge and The Sleepy Stoat
- add journal info to Old Mystic, Marla the Merchant, Borik the Smith and Tomas the Innkeeper
- load NPC journals and include NPC category in journal interface
- unlock NPC journal entry when talking to them

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684affc76fcc83299526e8a6f2689599